### PR TITLE
Add filter method to search todos.

### DIFF
--- a/src/HomeAction.js
+++ b/src/HomeAction.js
@@ -2,28 +2,71 @@ import React from 'react';
 import { ArrowLeft } from '@styled-icons/bootstrap'
 import TodoForm from './TodoForm';
 import Todos from './Todos';
+import { connect } from 'react-redux';
 
-export default class HomeAction extends React.PureComponent {
+class HomeAction extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			input: ''
+		}
+		this.setInput = this.setInput.bind(this);
+	}
+
+	setInput(event) {
+		const input = event.target.value;
+		this.setState( { input } );
+	}
+
+	getFilteredTodos( input ) {
+		const { todos } = this.props;
+		if ( ! input.length ) {
+			return [];
+		}
+		return todos.filter( ( todo ) => todo.task.indexOf(input) >= 0 );
+	}
+
+	renderFilteredTodos() {
+		const { input } = this.state;
+		const filteredTodos = this.getFilteredTodos( input );
+
+		if( !filteredTodos.length ) {
+			return <div>No todos found.</div> 
+		}
+
+		return filteredTodos.map( todo => { 
+			return <div key={todo.id}>{todo.task}</div> 
+		})
+	}
+
 	render() {
 		const { selectedDate, getTodosForDate, setView, view } = this.props;
 		const todayTodos = selectedDate ? getTodosForDate(selectedDate) : [];
-
+		const { input } = this.state;
+		
 		switch(view) {
 			case 'todo-form':
 				return <div className='home-todo-form'><TodoForm closeTodoForm={ () => setView('todos') } /></div>;
 			case 'search':
-				return <> 
+				return <div> 
 					<button onClick={ () => setView('todos') }>
 						<ArrowLeft size="25"  />
 					</button>
 					Todo
-					<input className='home-search-input' type="text" id="myInput" onkeyup="myFunction()" title="Type in a todo"></input>
-				</>;
+					<input className='home-search-input' type="text" id="myInput" onKeyUp={ (event) => this.setInput(event) } title="Type in a todo"></input>
+					{ input.length 
+						? this.renderFilteredTodos()
+						: <div>Search your todos.</div>
+					}
+				</div>;
 			default:
 				return <div className='home-todos'><Todos todos={ todayTodos } /></div>;
 		}
 	}
 }
 
+const mapStateToProps = state => ({
+	todos: state.todos,
+});
 
-
+export default connect(mapStateToProps, null)(HomeAction);


### PR DESCRIPTION
Fix #35 

**Features**
1. Render 'Search your todos.', if no user input.
1. Render 'No todos found.', if no matching todos.
1. Render filtered todos if matched input.

**Screenshots**
<img width="285" alt="螢幕快照 2020-11-16 下午3 36 41" src="https://user-images.githubusercontent.com/56378160/99305550-ef5fd900-2821-11eb-8918-ec2c306460e7.png">
<img width="297" alt="螢幕快照 2020-11-16 下午3 36 35" src="https://user-images.githubusercontent.com/56378160/99305551-eff86f80-2821-11eb-8f46-66eeaa337816.png">
<img width="292" alt="螢幕快照 2020-11-16 下午3 50 54" src="https://user-images.githubusercontent.com/56378160/99307021-eec84200-2823-11eb-9c83-f205f63cac75.png">


**Testing**
1. Click the search icon button.
1. Check if 'Search your todos.' rendered.
1. Type something to match current todos.
1. Check if matched todos rendered.
1. Type something doesn't match current todos.
1. Check if 'No todos found.' rendered.